### PR TITLE
fix: prevent page flash

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -26,14 +26,33 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en" className="min-h-screen">
+    <html lang="en" className="min-h-screen" suppressHydrationWarning>
+      <head>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `
+              (function() {
+                try {
+                  const theme = localStorage.getItem('theme');
+                  const systemPrefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+
+                  if (theme === 'dark' || (!theme && systemPrefersDark)) {
+                    document.documentElement.classList.add('dark');
+                  } else {
+                    document.documentElement.classList.remove('dark');
+                  }
+                } catch (e) {
+                  if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+                    document.documentElement.classList.add('dark');
+                  }
+                }
+              })();
+            `,
+          }}
+        />
+      </head>
       <body className={`${karla.className} min-h-full px-6`}>
         {/*<Analytics />*/}
-        <Script id="theme-toggle" strategy="afterInteractive">
-          {`document.documentElement.classList.toggle("dark", localStorage.theme ===
-        "dark" || (!("theme" in localStorage) &&
-        window.matchMedia("(prefers-color-scheme: dark)").matches))`}
-        </Script>
         <Header />
         <main className="mx-auto max-w-prose pb-4">
           {children}


### PR DESCRIPTION
# Eliminate dark/light mode flash on page load
![todd-tar](https://github.com/user-attachments/assets/178e081a-de73-44a1-840c-0643400c8a39)
## Problem


The website was experiencing a noticeable flash/blink when users visited pages with dark mode enabled. This happened because the theme script was loading **after** the initial page render, causing a jarring transition from light → dark mode.

### Root Cause
- Used `<Script strategy="afterInteractive">` which executes after React hydration
- Theme was applied too late in the rendering pipeline
- Server-side rendering always defaulted to light mode

## Solution

Replaced Next.js `<Script>` component with an inline script in the `<head>` that executes **synchronously** during HTML parsing, before any visual content is rendered.

## Visual Impact

<table>
<tr>
<td><img src="https://imgur.com/gzOyEAI.gif" alt="Before" width="400"></td>
<td><img src="https://i.imgur.com/LTEDVfj.gif" alt="After" width="400"></td>
</tr>
<tr>
<td align="center"><b>Before</b></td>
<td align="center"><b>After</b></td>
</tr>
</table>